### PR TITLE
Fix unicode logging crash.

### DIFF
--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -180,7 +180,6 @@ class RecordHandler(logging.Handler):
     if record.exc_info:
       message += '\n' + ''.join(traceback.format_exception(
           *record.exc_info))
-    message = message.decode('utf8', 'replace')
 
     log_record = LogRecord(
         record.levelno, record.name, os.path.basename(record.pathname),


### PR DESCRIPTION
Tested against:

```python
# coding=utf-8
import openhtf
from openhtf.output.callbacks.json_factory import OutputToJSON
import sys
from openhtf.core.measurements import Measurement


@openhtf.measures(Measurement('val'))
def utf8(test):
    val = u'☹'
    test.logger.error('uh oh')
    test.logger.error(val)
    test.measurements.val = val

if __name__ == '__main__':
    test = openhtf.Test(utf8)
    test.add_output_callbacks(
        OutputToJSON('log_demo.json')
    )
    test.execute(test_start=lambda: 'fake_dut')
```