### PR TITLE
Raise an exception if attachment name has a period

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -379,7 +379,10 @@ class PhaseState(mutablerecords.Record(
     Raises:
       DuplicateAttachmentError: Raised if there is already an attachment with
         the given name.
+      ValueError: Raised if the name contains a period
     """
+    if '.' in name:
+      raise ValueError('Attachment names cannot contain periods.')
     if name in self.phase_record.attachments:
       raise DuplicateAttachmentError('Duplicate attachment for %s' % name)
     if mimetype and not mimetypes.guess_extension(mimetype):


### PR DESCRIPTION
Should fix https://github.com/ShaperTools/FactoryTest/issues/318
@DanLipsitt 