### PR TITLE
Make setup.py globs more specific to not select directories. From Google.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,11 +187,11 @@ setup(
     maintainer_email='jethier@google.com',
     packages=find_packages(exclude='examples'),
     package_data={'openhtf': ['output/proto/*.proto',
-                              'output/web_gui/dist/*',
+                              'output/web_gui/dist/*.*',
                               'output/web_gui/dist/css/*',
                               'output/web_gui/dist/js/*',
                               'output/web_gui/dist/img/*',
-                              'output/web_gui/*']},
+                              'output/web_gui/*.*']},
     cmdclass={
         'build_proto': BuildProtoCommand,
         'clean': CleanCommand,


### PR DESCRIPTION
Tested on Ubuntu 16.04, works with both Pip 8.1.1 (the default) and 20.1 (the latest).